### PR TITLE
Removing extra space in pom.xml

### DIFF
--- a/react-app/pom.xml
+++ b/react-app/pom.xml
@@ -1,4 +1,4 @@
- <?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
     <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
         <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
There's an extra space at the beginning of the react pom.xml causing a non-valid XML document error when the build happens in the AEM Cloud Manager.