### PR TITLE
Updated dependency on core components to 2.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,12 +494,12 @@
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.all</artifactId>
                 <type>zip</type>
-                <version>2.0.4</version>
+                <version>2.2.2</version>
             </dependency>
              <dependency>
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.core</artifactId>
-                <version>2.0.4</version>
+                <version>2.2.2</version>
             </dependency>
             <!-- Use latest version of export json -->
             <dependency>


### PR DESCRIPTION
This is required for this sample to work on production instances (e.g. with nosamplecontent runmode)